### PR TITLE
Allow for `=` signs in environment variable values

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -40,6 +40,11 @@ func (a *App) Execute() error {
 		return err
 	}
 
+	env, err := ports.HostEnv()
+	if err != nil {
+		return err
+	}
+
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	cliCtx := kong.Parse(a,
 		kong.Name("git-age"),
@@ -47,7 +52,7 @@ func (a *App) Execute() error {
 		kong.BindTo(os.Stdout, (*ports.STDOUT)(nil)),
 		kong.BindTo(os.Stdin, (*ports.STDIN)(nil)),
 		kong.Bind(ports.CWD(wd)),
-		kong.Bind(ports.HostEnv()),
+		kong.Bind(env),
 		kong.Vars{
 			"XDG_CONFIG_HOME": filepath.ToSlash(xdg.ConfigHome),
 		})

--- a/core/ports/os.go
+++ b/core/ports/os.go
@@ -20,11 +20,11 @@ type STDOUT io.Writer
 func HostEnv() OSEnv {
 	env := make(OSEnv)
 	for _, v := range os.Environ() {
-		keyValue := strings.Split(v, "=")
-		if len(keyValue) != 2 {
-			panic(fmt.Sprintf("unexpected environment variable %s", keyValue))
+		key, value, found := strings.Cut(v, "=")
+		if !found {
+			panic(fmt.Sprintf("unexpected environment variable %s", v))
 		}
-		env[keyValue[0]] = keyValue[1]
+		env[key] = value
 	}
 
 	return env

--- a/core/ports/os.go
+++ b/core/ports/os.go
@@ -17,17 +17,17 @@ type STDIN io.ReadCloser
 
 type STDOUT io.Writer
 
-func HostEnv() OSEnv {
+func HostEnv() (OSEnv, error) {
 	env := make(OSEnv)
 	for _, v := range os.Environ() {
 		key, value, found := strings.Cut(v, "=")
 		if !found {
-			panic(fmt.Sprintf("unexpected environment variable %s", v))
+			return nil, fmt.Errorf("unexpected environment variable %q", v)
 		}
 		env[key] = value
 	}
 
-	return env
+	return env, nil
 }
 
 func NewOSEnv() OSEnv {


### PR DESCRIPTION
Base64 strings and authentication tokens could contain `=` signs in their values.

Currently, `git-age` crashes when that happens, failing to clean/smudge files and rendering git unusable.

`os.Environ()` returns each env variable as `key=value`, so it could be split only by the first `=` sign and the second part of the slice (with `=` signs) the whole value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and parsing logic for environment variables, enhancing robustness and clarity.
- **New Features**
	- Introduced a new variable for retrieving and validating the host environment before binding it to the CLI context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->